### PR TITLE
Fix bug when clicking on the reference of a line

### DIFF
--- a/Github HideWhitespaceChanges by default.user.js
+++ b/Github HideWhitespaceChanges by default.user.js
@@ -30,15 +30,15 @@
   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **/
 
-history.pushState = ( f => function pushState(){
-    const returnValue = f.apply(this, arguments);
+history.pushState = (originalPushState => function pushState(){
+    const returnValue = originalPushState.apply(this, arguments);
     window.dispatchEvent(new Event('pushState'));
     window.dispatchEvent(new Event('locationchange'));
     return returnValue;
 })(history.pushState);
 
-history.replaceState = ( f => function replaceState(){
-    const returnValue = f.apply(this, arguments);
+history.replaceState = (originalReplaceState => function replaceState(){
+    const returnValue = originalReplaceState.apply(this, arguments);
     window.dispatchEvent(new Event('replaceState'));
     window.dispatchEvent(new Event('locationchange'));
     return returnValue;

--- a/Github HideWhitespaceChanges by default.user.js
+++ b/Github HideWhitespaceChanges by default.user.js
@@ -30,20 +30,18 @@
   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **/
 
-
-/* These are the modifications: */
 history.pushState = ( f => function pushState(){
-    var ret = f.apply(this, arguments);
+    const returnValue = f.apply(this, arguments);
     window.dispatchEvent(new Event('pushState'));
     window.dispatchEvent(new Event('locationchange'));
-    return ret;
+    return returnValue;
 })(history.pushState);
 
 history.replaceState = ( f => function replaceState(){
-    var ret = f.apply(this, arguments);
+    const returnValue = f.apply(this, arguments);
     window.dispatchEvent(new Event('replaceState'));
     window.dispatchEvent(new Event('locationchange'));
-    return ret;
+    return returnValue;
 })(history.replaceState);
 
 window.addEventListener('popstate',()=>{

--- a/Github HideWhitespaceChanges by default.user.js
+++ b/Github HideWhitespaceChanges by default.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Github HideWhitespaceChanges by default
 // @namespace    ruimcf
-// @version      0.2
+// @version      0.3
 // @description  Turn on Github's hide whitespace changes feature when reviewing files of a PR
 // @author       Rui Fonseca
 // @website      https://github.com/ruimcf
@@ -31,19 +31,19 @@
 **/
 
 
-/* Modify history events to trigger our function */
-history.pushState = (originalFn => (...args) => {
-    const returnValue = originalFn.apply(this, ...args);
+/* These are the modifications: */
+history.pushState = ( f => function pushState(){
+    var ret = f.apply(this, arguments);
     window.dispatchEvent(new Event('pushState'));
     window.dispatchEvent(new Event('locationchange'));
-    return returnValue;
+    return ret;
 })(history.pushState);
 
-history.replaceState = (originalFn => (...args) => {
-    const returnValue = originalFn.apply(this, ...args);
+history.replaceState = ( f => function replaceState(){
+    var ret = f.apply(this, arguments);
     window.dispatchEvent(new Event('replaceState'));
     window.dispatchEvent(new Event('locationchange'));
-    return returnValue;
+    return ret;
 })(history.replaceState);
 
 window.addEventListener('popstate',()=>{


### PR DESCRIPTION
The previous version introduced a bug that made it impossible clicking on the line to get the permalink to that line